### PR TITLE
 Add "Get Classtimes" Functionality to SigaController

### DIFF
--- a/src/controllers/SigaController.ts
+++ b/src/controllers/SigaController.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from "express";
 import { LoginDTO } from "../dtos/Auth/LoginDTO";
 import { SigaService } from "../services/SigaService";
+import { DayEnum } from "../enums/DayEnum";
 
 export class SigaController {
     private service: SigaService;
@@ -13,6 +14,14 @@ export class SigaController {
         const { username, password } = req.body;
 
         const data = await this.service.getAbsencesInfo(new LoginDTO(username, password));
+
+        res.status(200).json(data)
+    }
+
+    public async getClasstimes(req: Request, res: Response) {
+        const { username, password } = req.body;
+
+        const data = await this.service.getClasstimeInfo(new LoginDTO(username, password), req.query.day as DayEnum);
 
         res.status(200).json(data)
     }

--- a/src/controllers/SigaController.ts
+++ b/src/controllers/SigaController.ts
@@ -1,7 +1,6 @@
 import { Request, Response } from "express";
 import { LoginDTO } from "../dtos/Auth/LoginDTO";
 import { SigaService } from "../services/SigaService";
-import { DayEnum } from "../enums/DayEnum";
 
 export class SigaController {
     private service: SigaService;
@@ -21,7 +20,7 @@ export class SigaController {
     public async getClasstimes(req: Request, res: Response) {
         const { username, password } = req.body;
 
-        const data = await this.service.getClasstimeInfo(new LoginDTO(username, password), req.query.day as DayEnum);
+        const data = await this.service.getClasstimeInfo(new LoginDTO(username, password));
 
         res.status(200).json(data)
     }

--- a/src/dtos/Absences/AbsenceDTO.ts
+++ b/src/dtos/Absences/AbsenceDTO.ts
@@ -1,13 +1,13 @@
+import { DisciplineDTO } from "../Disciplines/DisciplineDTO";
+
 export class AbsenceDTO {
     public presences: number;
     public absences: number;
-    public discipline: string;
-    public teacher?: string;
+    public discipline?: DisciplineDTO;
 
-    constructor(presences: number, absences: number, discipline: string, teacher?: string) {
+    constructor(presences: number, absences: number, discipline?: DisciplineDTO) {
         this.presences = presences;
         this.absences = absences;
         this.discipline = discipline;
-        this.teacher = teacher;
     }
 }

--- a/src/dtos/Classtime/ClasstimeDTO.ts
+++ b/src/dtos/Classtime/ClasstimeDTO.ts
@@ -2,14 +2,12 @@ import { DayEnum } from "../../enums/DayEnum";
 import { DisciplineDTO } from "../Disciplines/DisciplineDTO";
 
 export class ClasstimeDTO {
-    public discipline: DisciplineDTO;
-    public day: DayEnum;
     public startTime: string;
     public endTime: string;
+    public discipline?: DisciplineDTO;
 
-    constructor(discipline: DisciplineDTO, day: DayEnum, startTime: string, endTime: string) {
+    constructor(startTime: string, endTime: string, discipline?: DisciplineDTO) {
         this.discipline = discipline;
-        this.day = day;
         this.startTime = startTime;
         this.endTime = endTime;
     }

--- a/src/dtos/Classtime/ClasstimeDTO.ts
+++ b/src/dtos/Classtime/ClasstimeDTO.ts
@@ -1,0 +1,16 @@
+import { DayEnum } from "../../enums/DayEnum";
+import { DisciplineDTO } from "../Disciplines/DisciplineDTO";
+
+export class ClasstimeDTO {
+    public discipline: DisciplineDTO;
+    public day: DayEnum;
+    public startTime: string;
+    public endTime: string;
+
+    constructor(discipline: DisciplineDTO, day: DayEnum, startTime: string, endTime: string) {
+        this.discipline = discipline;
+        this.day = day;
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+}

--- a/src/dtos/Classtime/DayTimesDTO.ts
+++ b/src/dtos/Classtime/DayTimesDTO.ts
@@ -1,0 +1,12 @@
+import { DayEnum } from "../../enums/DayEnum";
+import { ClasstimeDTO } from "./ClasstimeDTO";
+
+export class DayTimesDTO {
+    public day!: DayEnum;
+    public classtimeDto!: ClasstimeDTO[];
+
+    constructor(day: DayEnum, classtimeDto: ClasstimeDTO[]) {
+        this.day = day;
+        this.classtimeDto = classtimeDto;
+    }
+}

--- a/src/enums/DayEnum.ts
+++ b/src/enums/DayEnum.ts
@@ -1,8 +1,8 @@
 export enum DayEnum {
-    MONDAY = "monday",
-    TUESDAY = "tuesday",
-    WEDNESDAY = "wednesday",
-    THURSDAY = "thursday",
-    FRIDAY = "friday",
-    SATURDAY = "saturday"
+    MONDAY = "Segunda-Feira",
+    TUESDAY = "Terça-Feira",
+    WEDNESDAY = "Quarta-Feira",
+    THURSDAY = "Quinta-Feira",
+    FRIDAY = "Sexta-Feira",
+    SATURDAY = "Sábado",
 }

--- a/src/enums/DayEnum.ts
+++ b/src/enums/DayEnum.ts
@@ -1,0 +1,8 @@
+export enum DayEnum {
+    MONDAY = "monday",
+    TUESDAY = "tuesday",
+    WEDNESDAY = "wednesday",
+    THURSDAY = "thursday",
+    FRIDAY = "friday",
+    SATURDAY = "saturday"
+}

--- a/src/routes/SigaRouter.ts
+++ b/src/routes/SigaRouter.ts
@@ -10,5 +10,6 @@ router.get("/", () => {
 })
 
 router.get("/absences", (req: Request, res: Response) => controller.getAbsencesInfo(req, res));
+router.get("/classtimes", (req: Request, res: Response) => controller.getClasstimes(req, res));
 
 export default router;

--- a/src/services/ScraperService.ts
+++ b/src/services/ScraperService.ts
@@ -4,16 +4,15 @@ import { LoginDTO } from "../dtos/Auth/LoginDTO";
 import { ScrapUtils } from "../utils/ScrapUtils";
 import { AbsenceDTO } from "../dtos/Absences/AbsenceDTO";
 import { DisciplineDTO } from "../dtos/Disciplines/DisciplineDTO";
+import { ClasstimeDTO } from "../dtos/Classtime/ClasstimeDTO";
+import { DayEnum } from "../enums/DayEnum";
+import { DayTimesDTO } from "../dtos/Classtime/DayTimesDTO";
 
 export class ScraperService {
     private url: string = "https://siga.cps.sp.gov.br/aluno/login.aspx";
     private browser!: Browser;
     private page!: Page;
     private isAuth: boolean = false;
-
-    constructor() {
-        this.initPage().catch(console.error);;
-    }
 
     public async initPage() {
         if (!this.browser) {
@@ -26,7 +25,8 @@ export class ScraperService {
     }
 
     public async closePage() {
-        await this.page.close();          
+        await this.page.close();
+        await this.browser.close();
     }
 
     public async login(loginDto: LoginDTO): Promise<boolean> {
@@ -52,10 +52,12 @@ export class ScraperService {
     }
 
     public async getAbsencesInfo(loginDto: LoginDTO): Promise<AbsenceDTO[] | undefined> {
+        await this.initPage();
+
         if(await this.login(loginDto)) {
             const disciplines = await this.getDisciplinesInfo(loginDto);
             if(!disciplines) {
-                return undefined;
+                throw new Error();
             }
 
             await this.page.click("#ygtvlabelel11Span");
@@ -76,11 +78,15 @@ export class ScraperService {
                     }
                 };
 
-                const absenceDto = new AbsenceDTO(Number(textContents[2]), Number(textContents[3]), textContents[1]);
+                const presences = Number(textContents[2]);
+                const absences = Number(textContents[3]);
+                const disciplineName = textContents[1];
+
+                const absenceDto = new AbsenceDTO(presences, absences);
                 
-                const discipline = disciplines.find(discipline => discipline.name.includes(absenceDto.discipline));
+                const discipline = disciplines.find(discipline => discipline.name.includes(disciplineName));
                 if(discipline) {
-                    absenceDto.teacher = discipline.teacher;
+                    absenceDto.discipline = discipline;
                 }
 
                 absencesList.push(absenceDto);
@@ -91,6 +97,8 @@ export class ScraperService {
     }
 
     public async getDisciplinesInfo(loginDto: LoginDTO): Promise<DisciplineDTO[] | undefined> {
+        await this.initPage();
+
         if(await this.login(loginDto)) {
             await this.page.click("#ygtvlabelel9Span");
 
@@ -111,10 +119,69 @@ export class ScraperService {
                     }
                 };
 
-                disciplineList.push(new DisciplineDTO(textContents[0], textContents[1].split("-")[0].trim(), textContents[3]));
+                const cod = textContents[0];
+                const name = textContents[1].split("-")[0].trim();
+                const teacher = textContents[3];
+
+                disciplineList.push(new DisciplineDTO(cod, name, teacher));
             };
 
             return disciplineList;
+        }
+    }
+
+    public async getClasstimeInfo(loginDto: LoginDTO): Promise<DayTimesDTO[] | undefined> {
+        await this.initPage();
+        
+        if(await this.login(loginDto)) {
+            const disciplines = await this.getDisciplinesInfo(loginDto);
+            if(!disciplines) {
+                throw new Error();
+            }
+
+            const dayTimes: DayTimesDTO[] = [];
+
+            await this.page.waitForSelector(".GridClear", { visible: true });
+            const tables = await this.page.$$("#TABLE3 .GridClear");
+            const tableTitles = await this.page.$$("#TABLE3 .TextBlock");
+
+            let i = 0;
+            for(const table of tables) {
+                const tableLines = await table.$$("tr");
+                const tableLinesWithoutFirst = tableLines.slice(1);
+
+                const classtimeList: ClasstimeDTO[] = [];
+
+                for (const line of tableLinesWithoutFirst) {
+                    const textContents: string[] = [];
+    
+                    const cells = await line.$$("td");
+    
+                    for (const textElement of cells) {
+                        const text = await this.page.evaluate(el => el.textContent?.trim(), textElement);
+                        if(text) {
+                            textContents.push(text);
+                        }
+                    };
+    
+                    const startTime = textContents[0].split("-")[0].trim();
+                    const endTime = textContents[0].split("-")[1].trim();
+                    const disciplineCod = textContents[1].trim();
+                    const classtimeDto = new ClasstimeDTO(startTime, endTime);
+    
+                    const discipline = disciplines.find(discipline => discipline.cod.includes(disciplineCod));
+                    if(discipline) {
+                        classtimeDto.discipline = discipline;
+                    }
+    
+                    classtimeList.push(classtimeDto);
+                };
+
+                const day = await this.page.evaluate(el => el.textContent?.trim(), tableTitles[i]) as DayEnum;
+                dayTimes.push(new DayTimesDTO(day, classtimeList));
+                i++;
+            }
+            return dayTimes;
         }
     }
 }

--- a/src/services/SigaService.ts
+++ b/src/services/SigaService.ts
@@ -1,5 +1,7 @@
 import { AbsenceDTO } from "../dtos/Absences/AbsenceDTO";
 import { LoginDTO } from "../dtos/Auth/LoginDTO";
+import { ClasstimeDTO } from "../dtos/Classtime/ClasstimeDTO";
+import { DayEnum } from "../enums/DayEnum";
 import { ScraperService } from "./ScraperService";
 
 export class SigaService {
@@ -13,6 +15,15 @@ export class SigaService {
         const absencesList: AbsenceDTO[] | undefined = await this.scraperService.getAbsencesInfo(loginDto);
         if(absencesList) {
             return absencesList;
+        } else {
+            throw new Error("Erro ao pegar informações.");
+        }
+    }
+
+    public async getClasstimeInfo(loginDto: LoginDTO, day: DayEnum): Promise<ClasstimeDTO[]> {
+        const classtimeList: ClasstimeDTO[] | undefined = await this.scraperService.getClasstimeInfo(loginDto, day);
+        if(classtimeList) {
+            return classtimeList;
         } else {
             throw new Error("Erro ao pegar informações.");
         }

--- a/src/services/SigaService.ts
+++ b/src/services/SigaService.ts
@@ -1,7 +1,7 @@
 import { AbsenceDTO } from "../dtos/Absences/AbsenceDTO";
 import { LoginDTO } from "../dtos/Auth/LoginDTO";
 import { ClasstimeDTO } from "../dtos/Classtime/ClasstimeDTO";
-import { DayEnum } from "../enums/DayEnum";
+import { DayTimesDTO } from "../dtos/Classtime/DayTimesDTO";
 import { ScraperService } from "./ScraperService";
 
 export class SigaService {
@@ -20,10 +20,10 @@ export class SigaService {
         }
     }
 
-    public async getClasstimeInfo(loginDto: LoginDTO, day: DayEnum): Promise<ClasstimeDTO[]> {
-        const classtimeList: ClasstimeDTO[] | undefined = await this.scraperService.getClasstimeInfo(loginDto, day);
-        if(classtimeList) {
-            return classtimeList;
+    public async getClasstimeInfo(loginDto: LoginDTO): Promise<DayTimesDTO[]> {
+        const dayTimesList: DayTimesDTO[] | undefined = await this.scraperService.getClasstimeInfo(loginDto);
+        if(dayTimesList) {
+            return dayTimesList;
         } else {
             throw new Error("Erro ao pegar informações.");
         }


### PR DESCRIPTION
**Description:**
This PR introduces a new feature for retrieving class times in the system. The following changes have been made:

1. **SigaController:**
   - Added a new method `getClasstimes` to fetch class times based on user credentials (username and password).
   - The new method interacts with the service layer to retrieve the data and responds with a JSON payload.

2. **DTOs:**
   - Introduced the `ClasstimeDTO` to structure information related to class times, such as start and end time, and associated discipline.
   - Created the `DayTimesDTO` to map class times for each day of the week, utilizing the `DayEnum`.
   - Modified the `AbsenceDTO` to remove the optional teacher field and replace the discipline string with a `DisciplineDTO`.

3. **Enums:**
   - Added the `DayEnum` to represent days of the week, supporting multiple languages (currently with Portuguese day names).

4. **ScraperService:**
   - Implemented `getClasstimeInfo` method to scrape class times, parsing the class schedule data and organizing it by day.
   - Integrated the `ClasstimeDTO` and `DayTimesDTO` to structure and return the data appropriately.

5. **SigaService:**
   - Created a wrapper method `getClasstimeInfo` in the service to interact with the scraper service and return class times.

6. **Routes:**
   - Added a new GET route `/classtimes` in the `SigaRouter` to expose the new functionality to the API.